### PR TITLE
Add Next.js TODO list example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# codex-test
+# TODO List App
+
+This repository contains a simple TODO list application built with Next.js and React.
+
+## Getting Started
+
+1. Install dependencies (requires Node.js):
+   ```bash
+   npm install
+   ```
+2. Run the development server:
+   ```bash
+   npm run dev
+   ```
+3. Open [http://localhost:3000](http://localhost:3000) in your browser to view the app.
+
+The app lets you add tasks to a list that is stored in component state.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "todo-app",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.1.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+
+export default function Home() {
+  const [task, setTask] = useState('');
+  const [todos, setTodos] = useState([]);
+
+  const addTodo = () => {
+    if (task.trim() === '') return;
+    setTodos([...todos, task.trim()]);
+    setTask('');
+  };
+
+  return (
+    <div style={{ padding: '2rem', fontFamily: 'Arial, sans-serif' }}>
+      <h1>TODO List</h1>
+      <div>
+        <input
+          value={task}
+          onChange={(e) => setTask(e.target.value)}
+          placeholder="Add a new task"
+        />
+        <button onClick={addTodo}>Add</button>
+      </div>
+      <ul>
+        {todos.map((todo, index) => (
+          <li key={index}>{todo}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create Next.js skeleton with scripts
- implement `pages/index.js` containing TODO list functionality
- update README instructions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841fad66f68832a958d0ea2091c0174